### PR TITLE
returned data frame from generateProductData

### DIFF
--- a/test/climatic_summary_demo.input.json
+++ b/test/climatic_summary_demo.input.json
@@ -1,0 +1,39 @@
+{
+  "data_params": {
+    "station_ids": [
+      67774010,
+      67775050,
+      67785020,
+      67791010,
+      67871020,
+      67875010,
+      67897020,
+      67963040,
+      67964020,
+      67965050,
+      67975040,
+      67991020
+    ],
+    "period": [
+      "1960-01-01",
+      "2011-01-01"
+    ],
+    "elements": [
+      2,
+      3,
+      4,
+      5
+    ]
+  },
+  "product_params": {
+    "date_time": "obsDatetime",
+    "station": "recordedFrom",
+    "elements": ["obsValue"],
+    "to": "annual",
+    "summaries": {
+      "mean": "mean",
+      "max": "max",
+      "min": "min"
+    }
+  }
+}


### PR DESCRIPTION
The `generateProductData()` function now returns a filtered data frame.

You can test with the `climatic-summary` endpoint. I added a JSON file with some suggested test data. The test data is based on the suggestion from @dannyparsons in Slack today.
The returned data will be slightly different from the results on Slack because the JSON file data filter specification does not include all the `elements` (it was too much work to add them all). However, I tested the Python separately with the unfiltered data and it returned the correct results.

Please check if the returned results are OK for your needs. 
Thanks!
