### PR TITLE
Add versioning to r package installs

### DIFF
--- a/install_packages.R
+++ b/install_packages.R
@@ -1,4 +1,5 @@
 install.packages('devtools',repos = "http://cran.us.r-project.org")
 install.packages("rlang",repos = "http://cran.us.r-project.org")
-devtools::install_github("IDEMSInternational/cdms.products")
+# Note - the products library is not currently versionined so manually update head sha ref to install version
+devtools::install_github("IDEMSInternational/cdms.products",ref="2d4babe132927b27e1ac311d0a4693f702d68578")
 q()


### PR DESCRIPTION
Docker automatically caches build stages, and so will only ever update the R package imported (via git) if there are changes to files in a previous build step. To force update I've included the specific github commit sha of the current package, which can be updated as required to force the server to deploy with a specific version of the r repo code

@dannyparsons @lloyddewit  - Feel free to update as required and merge whenever you want the server version updated