### PR TITLE
Ensured that data frames that contain NaN values can be returned to the client as JSON

### DIFF
--- a/app/utils/response.py
+++ b/app/utils/response.py
@@ -39,6 +39,7 @@ def get_error_response(message: str, result: List[Any] = None):
 
 
 def get_dataframe_response(option: DataFrameResponseType, dataframe: DataFrame,):
+    dataframe = dataframe.fillna('') # JSON cannot represent NaN values, so change to space
     if(option.value == DataFrameResponseType.columns.value):
         return dataframe.to_dict(orient='split')
     if(option.value == DataFrameResponseType.records.value):


### PR DESCRIPTION
JSON cannot represent NaN values, so we replace the NaN values with a space.
Before this fix, the test specified in `climatic_summary_demo.input.json` (see below) failed.
This test now passes.

@dannyparsons Thank you for the suggestion!
@chrismclarke Please could you review/merge? thanks

```
{
  "data_params": {
    "station_ids": [
      67774010, 67775050, 67785020, 67791010, 67871020, 67875010, 67897020,
      67963040, 67964020, 67965050, 67975040, 67991020
    ],
    "period": ["1960-01-01", "2011-01-01"],
    "elements": [2, 3, 4, 5]
  },
  "product_params": {
    "to": "annual"
  }
}
```